### PR TITLE
Fix: Timezone comparison error preventing historical statistics insertion

### DIFF
--- a/custom_components/dropcountr/coordinator.py
+++ b/custom_components/dropcountr/coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from pydropcountr import DropCountrClient, ServiceConnection, UsageData, UsageResponse
@@ -272,9 +272,12 @@ class DropCountrUsageDataUpdateCoordinator(
                 from datetime import datetime
 
                 if isinstance(last_time, (int, float)):
-                    last_time_dt = datetime.fromtimestamp(last_time)
+                    last_time_dt = datetime.fromtimestamp(last_time, tz=UTC)
                 else:
                     last_time_dt = last_time
+                    # Ensure it has timezone info
+                    if last_time_dt.tzinfo is None:
+                        last_time_dt = last_time_dt.replace(tzinfo=UTC)
 
                 _LOGGER.debug(
                     f"Continuing {metric_type} statistics from {last_time_dt}, sum={existing_sum}"
@@ -284,6 +287,12 @@ class DropCountrUsageDataUpdateCoordinator(
                 oldest_historical_date = min(
                     usage_data.start_date for usage_data in historical_data
                 )
+                # Ensure both datetimes have timezone info for comparison
+                if oldest_historical_date.tzinfo is None:
+                    oldest_historical_date = oldest_historical_date.replace(
+                        tzinfo=UTC
+                    )
+
                 if last_time_dt > oldest_historical_date:
                     _LOGGER.warning(
                         f"Last processed time ({last_time_dt}) is newer than historical data ({oldest_historical_date}). "


### PR DESCRIPTION
## Problem
The statistics insertion was failing with a timezone comparison error:
```
TypeError: can't compare offset-naive and offset-aware datetimes
```

This was happening when comparing the last processed timestamp from the statistics database with historical data timestamps, preventing all historical statistics from being inserted.

## Root Cause
The comparison between `last_time_dt` (from statistics) and `oldest_historical_date` (from usage data) failed because one datetime was timezone-aware and the other was timezone-naive.

## Solution
- **Add timezone handling**: Ensure both datetimes have UTC timezone info before comparison
- **Use datetime.UTC**: Replace pytz with standard library for linting compliance
- **Handle mixed formats**: Support both timestamp and datetime formats from statistics system
- **Consistent timezone usage**: Use UTC throughout for reliable comparisons

## Changes
- Fix timezone comparison in `_insert_historical_statistics` method
- Add proper timezone normalization for both timestamps
- Use `datetime.UTC` instead of `pytz.UTC` for linting compliance
- Enhanced error handling for mixed datetime formats

## Expected Result
After this fix:
1. ✅ No more TypeError crashes during statistics insertion
2. ✅ Proper detection of corrupted timestamps (if any)
3. ✅ Successful insertion of historical data with correct timestamps
4. ✅ Fixed graphs showing historical data with original dates instead of current timestamps

## Testing
Deploy and verify:
- No timezone comparison errors in logs
- Historical statistics being inserted successfully
- Water usage graphs showing correct historical timestamps

🤖 Generated with [Claude Code](https://claude.ai/code)