### PR TITLE
Fix PyDropCountr get_usage datetime parameters to use UTC

### DIFF
--- a/custom_components/dropcountr/__init__.py
+++ b/custom_components/dropcountr/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from pydropcountr import DropCountrClient
 from requests.exceptions import RequestException
@@ -174,7 +174,7 @@ def setup_service(hass: HomeAssistant) -> None:
 
         # Default to last 24 hours if no dates provided
         if not start_date or not end_date:
-            end_dt = datetime.now()
+            end_dt = datetime.now(UTC)
             start_dt = end_dt - timedelta(days=1)
         else:
             try:

--- a/custom_components/dropcountr/coordinator.py
+++ b/custom_components/dropcountr/coordinator.py
@@ -119,10 +119,10 @@ class DropCountrUsageDataUpdateCoordinator(
         """Get usage data for a specific service connection."""
         try:
             # Get usage from the start of current month to ensure monthly totals are accurate
-            end_date = datetime.now()
+            end_date = datetime.now(UTC)
             # Start from the beginning of the current month, or 45 days ago, whichever is earlier
             # This ensures we get full month data plus some history for weekly totals
-            month_start = datetime(end_date.year, end_date.month, 1)
+            month_start = datetime(end_date.year, end_date.month, 1, tzinfo=UTC)
             start_date = min(month_start, end_date - timedelta(days=45))
 
             _LOGGER.debug(


### PR DESCRIPTION
## Summary
- Fix PyDropCountr get_usage datetime parameters to use UTC timezone
- PyDropCountr expects UTC datetimes but integration was passing naive datetime objects
- Updated coordinator.py and __init__.py to use proper UTC timezone-aware datetimes

## Test plan
- [x] All existing tests pass
- [x] Linting passes
- [x] Changes tested for proper UTC datetime handling

🤖 Generated with [Claude Code](https://claude.ai/code)