### PR TITLE
Fix StatisticData TypedDict usage in statistics insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2025-06-20
+
 ### Changed
 - **BREAKING**: Improved thread safety across the integration requiring Home Assistant 2025.6.0+
 - Optimized API call efficiency with intelligent 5-minute caching, reducing redundant service connection requests by 60-70%

--- a/custom_components/dropcountr/coordinator.py
+++ b/custom_components/dropcountr/coordinator.py
@@ -463,7 +463,7 @@ class DropCountrUsageDataUpdateCoordinator(
             )
 
             # Create statistics data
-            statistics = []
+            statistics: list[StatisticData] = []
             current_sum = existing_sum
 
             for usage_data in historical_data:
@@ -493,25 +493,14 @@ class DropCountrUsageDataUpdateCoordinator(
 
                 current_sum += value
 
-                # Create and validate StatisticData object
-                stat_data = StatisticData(
-                    start=local_start_date,
-                    state=value,
-                    sum=current_sum,
-                )
+                # Create StatisticData dictionary (TypedDict)
+                stat_data: StatisticData = {
+                    "start": local_start_date,
+                    "state": value,
+                    "sum": current_sum,
+                }
 
-                # Validate the created object before adding to list
-                if (
-                    hasattr(stat_data, "start")
-                    and hasattr(stat_data, "state")
-                    and hasattr(stat_data, "sum")
-                ):
-                    statistics.append(stat_data)
-                else:
-                    _LOGGER.error(
-                        f"Created invalid StatisticData object: {type(stat_data)}, {stat_data}"
-                    )
-                    continue
+                statistics.append(stat_data)
 
             if statistics:
                 try:
@@ -519,18 +508,16 @@ class DropCountrUsageDataUpdateCoordinator(
                     # Add type checking to handle any unexpected data formats
                     try:
                         if len(statistics) > 1:
-                            # Ensure we have StatisticData objects with start attribute
-                            if hasattr(statistics[0], "start") and hasattr(
-                                statistics[-1], "start"
-                            ):
-                                date_range = f"{statistics[0].start.date()} to {statistics[-1].start.date()}"
+                            # Ensure we have statistics dicts with start key
+                            if "start" in statistics[0] and "start" in statistics[-1]:
+                                date_range = f"{statistics[0]['start'].date()} to {statistics[-1]['start'].date()}"
                             else:
                                 date_range = f"{len(statistics)} statistics (unable to determine date range)"
-                        elif hasattr(statistics[0], "start"):
-                            date_range = str(statistics[0].start.date())
+                        elif "start" in statistics[0]:
+                            date_range = str(statistics[0]["start"].date())
                         else:
                             date_range = "1 statistic (unable to determine date)"
-                    except (IndexError, AttributeError) as e:
+                    except (IndexError, KeyError) as e:
                         _LOGGER.debug(f"Error formatting statistics date range: {e}")
                         date_range = f"{len(statistics)} statistics"
 

--- a/custom_components/dropcountr/manifest.json
+++ b/custom_components/dropcountr/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["pydropcountr"],
   "requirements": ["pydropcountr==0.1.2"],
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "home-assistant-dropcountr"
-version = "0.1.2"
+version = "0.1.4"
 description = "Home Assistant integration for DropCountr water monitoring"
 authors = [
     {name = "Matt Colyer", email = "matt@colyer.name"}


### PR DESCRIPTION
## Summary
- Fix StatisticData TypedDict usage instead of treating it as a class constructor
- Add proper type annotations for statistics data structures
- Remove unnecessary validation code that was causing error logs

## Problem
The integration was logging errors like:
```
Created invalid StatisticData object: <class 'dict'>, {'start': datetime.datetime(2025, 5, 6, 0, 0, tzinfo=zoneinfo.ZoneInfo(key='America/Los_Angeles')), 'state': 0.0, 'sum': 0.0}
```

This occurred because `StatisticData` is a `TypedDict`, not a class constructor, but the code was trying to use it as `StatisticData(start=..., state=..., sum=...)`.

## Changes
- **Fixed StatisticData creation**: Use dictionary syntax `{"start": ..., "state": ..., "sum": ...}` with proper type annotation
- **Added type annotations**: `statistics: list[StatisticData] = []` and `stat_data: StatisticData = {...}`
- **Updated validation logic**: Check dictionary keys instead of object attributes
- **Removed unnecessary validation**: Eliminated complex validation code that was causing the error logs

## Test Plan
- [x] Code linting passes (`scripts/lint`)
- [x] No syntax or type errors
- [ ] Test statistics insertion in Home Assistant environment
- [ ] Verify error logs no longer appear
- [ ] Confirm historical data statistics work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)