### PR TITLE
fix: add recorder statistics unit classes

### DIFF
--- a/custom_components/dropcountr/coordinator.py
+++ b/custom_components/dropcountr/coordinator.py
@@ -22,7 +22,7 @@ from homeassistant.components.recorder.statistics import (
     get_last_statistics,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CURRENCY_DOLLAR, UnitOfVolume
+from homeassistant.const import CURRENCY_DOLLAR, VOLUME, UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -362,21 +362,25 @@ class DropCountrUsageDataUpdateCoordinator(
                 "id": f"{DOMAIN}:{id_prefix}_total_gallons",
                 "name": f"DropCountr {service_connection.name} Total Water Usage",
                 "unit": UnitOfVolume.GALLONS,
+                "unit_class": VOLUME,
             },
             "irrigation_gallons": {
                 "id": f"{DOMAIN}:{id_prefix}_irrigation_gallons",
                 "name": f"DropCountr {service_connection.name} Irrigation Water Usage",
                 "unit": UnitOfVolume.GALLONS,
+                "unit_class": VOLUME,
             },
             "irrigation_events": {
                 "id": f"{DOMAIN}:{id_prefix}_irrigation_events",
                 "name": f"DropCountr {service_connection.name} Irrigation Events",
                 "unit": None,
+                "unit_class": None,
             },
             "total_cost": {
                 "id": f"{DOMAIN}:{id_prefix}_total_cost",
                 "name": f"DropCountr {service_connection.name} Total Water Cost",
                 "unit": CURRENCY_DOLLAR,
+                "unit_class": None,
             },
         }
 
@@ -443,6 +447,7 @@ class DropCountrUsageDataUpdateCoordinator(
                 name=config["name"],
                 source=DOMAIN,
                 statistic_id=statistic_id,
+                unit_class=config["unit_class"],
                 unit_of_measurement=config["unit"],
             )
 

--- a/tests/test_cost_statistics.py
+++ b/tests/test_cost_statistics.py
@@ -11,6 +11,7 @@ from custom_components.dropcountr.const import COST_PER_GALLON, DOMAIN
 from custom_components.dropcountr.coordinator import (
     DropCountrUsageDataUpdateCoordinator,
 )
+from homeassistant.const import VOLUME
 
 from .const import MOCK_CONFIG, MOCK_SERVICE_CONNECTION
 
@@ -122,6 +123,37 @@ async def test_cost_calculation_in_statistics(
 
     # Verify statistics were captured - 4 types including cost
     assert len(inserted_statistics) == 4
+
+    metadata_by_statistic_id = {
+        statistic_id: metadata for statistic_id, metadata, _stats in inserted_statistics
+    }
+    assert all(
+        "unit_class" in metadata for _id, metadata, _stats in inserted_statistics
+    )
+    assert (
+        metadata_by_statistic_id[
+            f"{DOMAIN}:dropcountr_{mock_service_connection.id}_total_gallons"
+        ]["unit_class"]
+        == VOLUME
+    )
+    assert (
+        metadata_by_statistic_id[
+            f"{DOMAIN}:dropcountr_{mock_service_connection.id}_irrigation_gallons"
+        ]["unit_class"]
+        == VOLUME
+    )
+    assert (
+        metadata_by_statistic_id[
+            f"{DOMAIN}:dropcountr_{mock_service_connection.id}_irrigation_events"
+        ]["unit_class"]
+        is None
+    )
+    assert (
+        metadata_by_statistic_id[
+            f"{DOMAIN}:dropcountr_{mock_service_connection.id}_total_cost"
+        ]["unit_class"]
+        is None
+    )
 
     # Find the cost statistics
     total_cost_stats = next(


### PR DESCRIPTION
Adds explicit recorder statistics unit_class metadata for DropCountr external statistics so the integration is compatible with the Home Assistant recorder statistics API change that becomes required in HA 2026.11.\n\nChanges:\n- Set unit_class=VOLUME for gallon-based statistics.\n- Set unit_class=None for unitless irrigation event counts and dollar cost statistics.\n- Extend cost/statistics tests to assert every StatisticMetaData payload includes unit_class.\n\nVerification:\n- uv run ruff check .\n- uv run ruff format --check .\n- uv run pytest tests/ -v --cov=custom_components.dropcountr --cov-report=xml