### PR TITLE
fix: split DropCountr hourly usage requests by day

### DIFF
--- a/custom_components/dropcountr/__init__.py
+++ b/custom_components/dropcountr/__init__.py
@@ -27,6 +27,7 @@ from .coordinator import (
     DropCountrRuntimeData,
     DropCountrUsageDataUpdateCoordinator,
 )
+from .hourly import fetch_hourly_usage_in_daily_windows
 
 SERVICE_LIST_USAGE = "list_usage"
 SERVICE_GET_SERVICE_CONNECTION = "get_service_connection"
@@ -209,11 +210,11 @@ def setup_service(hass: HomeAssistant) -> None:
 
         try:
             usage_response = await hass.async_add_executor_job(
-                entry.runtime_data.client.get_usage,
+                fetch_hourly_usage_in_daily_windows,
+                entry.runtime_data.client,
                 service_connection_id,
                 start_dt,
                 end_dt,
-                "hour",  # Use hourly granularity
             )
             elapsed = time.time() - start_time
             data_count = (

--- a/custom_components/dropcountr/coordinator.py
+++ b/custom_components/dropcountr/coordinator.py
@@ -35,6 +35,7 @@ from .const import (
     SERVICE_CONNECTION_SCAN_INTERVAL,
     USAGE_SCAN_INTERVAL,
 )
+from .hourly import fetch_hourly_usage_in_daily_windows
 
 
 @dataclass
@@ -234,11 +235,11 @@ class DropCountrUsageDataUpdateCoordinator(
             )
 
             api_start = time.time()
-            result = self.client.get_usage(
+            result = fetch_hourly_usage_in_daily_windows(
+                self.client,
                 service_connection_id=service_connection_id,
                 start_date=start_date,
                 end_date=end_date,
-                period="hour",
             )
             api_elapsed = time.time() - api_start
             total_elapsed = time.time() - start_time

--- a/custom_components/dropcountr/hourly.py
+++ b/custom_components/dropcountr/hourly.py
@@ -1,0 +1,72 @@
+"""Hourly DropCountr usage fetching helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import logging
+
+from pydropcountr import DropCountrClient, UsageData, UsageResponse
+
+_LOGGER = logging.getLogger(__package__)
+
+
+def fetch_hourly_usage_in_daily_windows(
+    client: DropCountrClient,
+    service_connection_id: int,
+    start_date: datetime,
+    end_date: datetime,
+) -> UsageResponse | None:
+    """Fetch hourly usage in API-safe daily windows.
+
+    DropCountr silently returns an empty hourly response for multi-day ranges.
+    Split larger ranges into <=24-hour requests and aggregate the returned records.
+    """
+    if end_date <= start_date:
+        return None
+
+    usage_data_by_record: dict[tuple[str, float, float, float, bool], UsageData] = {}
+    first_response: UsageResponse | None = None
+    cursor = start_date
+    request_count = 0
+
+    while cursor < end_date:
+        window_end = min(cursor + timedelta(days=1), end_date)
+        request_count += 1
+        response = client.get_usage(
+            service_connection_id=service_connection_id,
+            start_date=cursor,
+            end_date=window_end,
+            period="hour",
+        )
+        if response is not None:
+            if first_response is None:
+                first_response = response
+            if response.usage_data:
+                for usage in response.usage_data:
+                    record_key = (
+                        usage.during,
+                        usage.total_gallons,
+                        usage.irrigation_gallons,
+                        usage.irrigation_events,
+                        usage.is_leaking,
+                    )
+                    usage_data_by_record[record_key] = usage
+        cursor = window_end
+
+    usage_data = sorted(usage_data_by_record.values(), key=lambda data: data.start_date)
+    if first_response is None:
+        return None
+
+    _LOGGER.debug(
+        "Fetched %d hourly records for service %s using %d daily window request(s)",
+        len(usage_data),
+        service_connection_id,
+        request_count,
+    )
+
+    return UsageResponse(
+        usage_data=usage_data,
+        total_items=len(usage_data),
+        api_id=first_response.api_id,
+        consumed_via_id=first_response.consumed_via_id,
+    )

--- a/tests/test_historical_data.py
+++ b/tests/test_historical_data.py
@@ -1,6 +1,6 @@
 """Test historical data functionality."""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch
 
 from pydropcountr import ServiceConnection, UsageData, UsageResponse
@@ -15,6 +15,7 @@ from custom_components.dropcountr.const import (
 from custom_components.dropcountr.coordinator import (
     DropCountrUsageDataUpdateCoordinator,
 )
+from custom_components.dropcountr.hourly import fetch_hourly_usage_in_daily_windows
 
 from .const import MOCK_CONFIG, MOCK_SERVICE_CONNECTION
 
@@ -341,3 +342,89 @@ async def test_no_duplicate_events_on_subsequent_updates(
         second_call_count = mock_insert_stats.call_count
 
         assert second_call_count == 1  # No additional calls
+
+
+def test_fetch_hourly_usage_splits_multi_day_ranges(create_usage_response):
+    """Test hourly usage is fetched in daily windows to avoid empty API results."""
+    service_id = 12345
+    start_dt = datetime(2026, 6, 13, 2, 0, tzinfo=UTC)
+    end_dt = datetime(2026, 6, 16, 2, 0, tzinfo=UTC)
+
+    usage_by_window = [
+        UsageData(
+            during="2026-06-13T02:00:00.000Z/2026-06-13T03:00:00.000Z",
+            total_gallons=1.0,
+            irrigation_gallons=0.0,
+            irrigation_events=0,
+            is_leaking=False,
+        ),
+        UsageData(
+            during="2026-06-14T02:00:00.000Z/2026-06-14T03:00:00.000Z",
+            total_gallons=2.0,
+            irrigation_gallons=0.0,
+            irrigation_events=0,
+            is_leaking=False,
+        ),
+        UsageData(
+            during="2026-06-15T02:00:00.000Z/2026-06-15T03:00:00.000Z",
+            total_gallons=3.0,
+            irrigation_gallons=0.0,
+            irrigation_events=0,
+            is_leaking=False,
+        ),
+    ]
+
+    mock_client = Mock()
+    mock_client.get_usage.side_effect = [
+        create_usage_response([usage_by_window[0]]),
+        create_usage_response([usage_by_window[1]]),
+        create_usage_response([usage_by_window[2]]),
+    ]
+
+    result = fetch_hourly_usage_in_daily_windows(
+        mock_client,
+        service_connection_id=service_id,
+        start_date=start_dt,
+        end_date=end_dt,
+    )
+
+    assert result is not None
+    assert result.usage_data == usage_by_window
+    assert result.total_items == 3
+    assert mock_client.get_usage.call_count == 3
+
+    for call in mock_client.get_usage.call_args_list:
+        assert call.kwargs["service_connection_id"] == service_id
+        assert call.kwargs["period"] == "hour"
+        window = call.kwargs["end_date"] - call.kwargs["start_date"]
+        assert window <= timedelta(days=1)
+
+
+def test_fetch_hourly_usage_single_day_uses_one_request(create_usage_response):
+    """Test single-day hourly ranges do not get split unnecessarily."""
+    service_id = 12345
+    start_dt = datetime(2026, 6, 13, 2, 0, tzinfo=UTC)
+    end_dt = datetime(2026, 6, 13, 8, 0, tzinfo=UTC)
+    usage = UsageData(
+        during="2026-06-13T02:00:00.000Z/2026-06-13T03:00:00.000Z",
+        total_gallons=1.0,
+        irrigation_gallons=0.0,
+        irrigation_events=0,
+        is_leaking=False,
+    )
+
+    mock_client = Mock()
+    mock_client.get_usage.return_value = create_usage_response([usage])
+
+    result = fetch_hourly_usage_in_daily_windows(
+        mock_client,
+        service_connection_id=service_id,
+        start_date=start_dt,
+        end_date=end_dt,
+    )
+
+    assert result is not None
+    assert result.usage_data == [usage]
+    mock_client.get_usage.assert_called_once()
+    assert mock_client.get_usage.call_args.kwargs["start_date"] == start_dt
+    assert mock_client.get_usage.call_args.kwargs["end_date"] == end_dt


### PR DESCRIPTION
## Summary

Fix Home Assistant DropCountr hourly data polling returning zero records by splitting hourly API requests into daily windows.

## Root cause

The production log shows the integration logging in and finding both service connections successfully, then making one hourly request per service for a 7-day/168-hour range:

- `Fetching hourly usage data for service 1258809 (168 hours over 7 days)`
- `API fetch: service 1258809 returned no hourly data`
- `API fetch: service 1064520 returned no hourly data`

The recent last-month commits in this repo were statistics-related (`#93` unit classes and cumulative sum continuation) and did not introduce the empty response. The failing path is the existing hourly coordinator polling strategy: `DropCountrUsageDataUpdateCoordinator._get_usage_for_service()` requests `period="hour"` for the last 7 days in one call.

PyDropCountr/DropCountr API behavior discovered during the companion library work: hourly requests over multi-day ranges can silently return an empty response instead of an error, even when data exists. That matches the Home Assistant log exactly.

## Fix

- Add `fetch_hourly_usage_in_daily_windows()` helper.
- For hourly usage ranges larger than a day, call DropCountr in <=24-hour windows and aggregate the returned records.
- Use the helper in both:
  - automatic coordinator polling
  - `dropcountr.get_hourly_usage` service
- De-duplicate exact duplicate hourly records across adjacent/overlapping window responses while preserving distinct records that share an interval but differ in values.

## Tests

Added regression coverage for:

- multi-day hourly ranges being split into daily requests
- single-day hourly ranges using a single request

Local verification:

- `UV_LINK_MODE=copy uv run --extra dev pytest tests/ -q` — 44 passed
- `UV_LINK_MODE=copy uv run --extra dev ruff check .` — passed
- `UV_LINK_MODE=copy uv run --extra dev ruff format --check .` — passed
